### PR TITLE
Don't check if module file exists, just try to require it in protected mode.

### DIFF
--- a/lua/pac3/core/client/parts/vfs.lua
+++ b/lua/pac3/core/client/parts/vfs.lua
@@ -7,10 +7,7 @@ end
 
 --vfs (module) stuff
 
-if file.Exists("lua/bin/gmcl_vfs_win32.dll","GAME") or 
-   file.Exists("lua/bin/gmcl_vfs_linux.dll","GAME") or 
-   file.Exists("lua/bin/gmcl_vfs_osx.dll","GAME") then
-	require("vfs")
+if pcall(require, "vfs") then
 	hook.Add("pac.net.PlayerInitialSpawn","pac_vfsnotify",function()
 		pac.setHasVfs(true)
 		pac.requestVfsStatus()


### PR DESCRIPTION
This allows Lua wrappers to be made around other filesystem modules. The only downside to this is a message being printed to the console if the module is missing.